### PR TITLE
Add common SassDoc themes keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "keywords": [
     "Sassdoc",
     "Sassdoc Theme",
-    "reStructured Text"
+    "reStructured Text",
+    "sassdoc-theme"
   ],
   "directories": {
     "test": "test"


### PR DESCRIPTION
Greetings,

that's a pretty interesting theme you've built here.
Would you mind adding that keyword we try to use in every SassDoc themes, so that it's easier to list them on npm ?

https://www.npmjs.com/browse/keyword/sassdoc-theme

